### PR TITLE
fix/add request_uri to get all routes

### DIFF
--- a/NodeJS.stpl
+++ b/NodeJS.stpl
@@ -16,7 +16,7 @@ server {
     gzip_vary on;
 
     location / {
-    	proxy_pass      http://unix:%home%/%user%/web/%domain%/nodeapp/app.sock:/$1;
+    	proxy_pass      http://unix:%home%/%user%/web/%domain%/nodeapp/app.sock:$request_uri;
 	proxy_set_header X-Real-IP $remote_addr;
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header Host $host;

--- a/NodeJS.tpl
+++ b/NodeJS.tpl
@@ -4,7 +4,7 @@ server {
     error_log  /var/log/httpd/domains/%domain%.error.log error;
 
     location / {
-        proxy_pass      http://unix:%home%/%user%/web/%domain%/nodeapp/app.sock:/$1;
+        proxy_pass      http://unix:%home%/%user%/web/%domain%/nodeapp/app.sock:$request_uri;
         location ~* ^.+\.(%proxy_extentions%)$ {
             root           %docroot%;
             access_log     /var/log/httpd/domains/%domain%.log combined;


### PR DESCRIPTION
If you use node system routes, like express Router, you need add $request_uri variable to connect the socket with the resource, or the app never see the complete path. 